### PR TITLE
Optimize DatabaseModule DI setup

### DIFF
--- a/app/src/main/java/dev/sebastiano/bundel/storage/DataRepository.kt
+++ b/app/src/main/java/dev/sebastiano/bundel/storage/DataRepository.kt
@@ -4,7 +4,9 @@ import dev.sebastiano.bundel.notifications.ActiveNotification
 import dev.sebastiano.bundel.storage.model.DbNotification
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 internal class DataRepository @Inject constructor(
     private val database: RobertoDatabase,
     private val imagesStorage: ImagesStorage

--- a/app/src/main/java/dev/sebastiano/bundel/storage/DatabaseModule.kt
+++ b/app/src/main/java/dev/sebastiano/bundel/storage/DatabaseModule.kt
@@ -2,22 +2,27 @@ package dev.sebastiano.bundel.storage
 
 import android.app.Application
 import androidx.room.Room
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dev.sebastiano.bundel.storage.migrations.Migration1to2
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal class DatabaseModule {
+internal abstract class DatabaseModule {
 
-    @Provides
-    fun provideImagesStorage(application: Application): ImagesStorage = DiskImagesStorage(application)
+    @Binds
+    abstract fun provideImagesStorage(diskImagesStorage: DiskImagesStorage): ImagesStorage
 
-    @Provides
-    fun provideDatabase(application: Application): RobertoDatabase =
-        Room.databaseBuilder(application, RobertoDatabase::class.java, "roberto")
-            .addMigrations(Migration1to2)
-            .build()
+    companion object {
+        @Singleton
+        @Provides
+        fun provideDatabase(application: Application): RobertoDatabase =
+            Room.databaseBuilder(application, RobertoDatabase::class.java, "roberto")
+                .addMigrations(Migration1to2)
+                .build()
+    }
 }

--- a/app/src/main/java/dev/sebastiano/bundel/storage/DiskImagesStorage.kt
+++ b/app/src/main/java/dev/sebastiano/bundel/storage/DiskImagesStorage.kt
@@ -11,8 +11,11 @@ import dev.sebastiano.bundel.storage.ImagesStorage.NotificationIconSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
 
-internal class DiskImagesStorage(
+@Singleton
+internal class DiskImagesStorage @Inject constructor(
     private val application: Application
 ) : ImagesStorage {
 


### PR DESCRIPTION
I annotated the `provideDatabase` method with `@Singleton` annotation to avoid creating a new database instance for every injection. I also marked the `DataRepository` with `@Singleton` for similar reasons. Although `DatabaseModule` is installed in a singleton component, you still have to scope its bindings. See the following for more info: https://dagger.dev/hilt/components

I replaced the provide method with constructor injection to bind the `DiskImagesStorage`. However, one thing to note is that the ImagesStorage from DI is never used.