### PR TITLE
Don't auto update Kotlin version + KSP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,8 +64,23 @@ dependencies {
     dummyGoogleServices(files(rootProject.file("build-config/dummy-data/dummy-google-services.json")))
 }
 
-tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
-    rejectVersionIf {
-        isNonStable(candidate.version) && !isNonStable(currentVersion)
+tasks.withType<DependencyUpdatesTask> {
+    resolutionStrategy {
+        componentSelection {
+            all {
+                when {
+                    isNonStable(candidate.version) && !isNonStable(currentVersion) -> {
+                        reject("Updating stable to non stable is not allowed")
+                    }
+                    candidate.module == "kotlin-gradle-plugin" && candidate.version != libs.versions.kotlin.get() -> {
+                        reject("Keep Kotlin version on the version specified in libs.versions.toml")
+                    }
+                    // KSP versions are compound versions, starting with the kotlin version
+                    candidate.group == "com.google.devtools.ksp" && !candidate.version.startsWith(libs.versions.kotlin.get()) -> {
+                        reject("KSP needs to stick to Kotlin version")
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Add component selection rules rejecting any Kotlin version that does not match the version in the `libs.version.toml` file. The effect of this is that the Kotlin version will always require a manual version bump and will not be updated with `./gradlew versionCatalogUpdate`, which is probably the safest since Compose is also tied to a specific Kotlin version.

For KSP any version that does not match the specified Kotlin version is rejected so that the KSP and Kotlin versions should always match.